### PR TITLE
Don't die if examples are not available

### DIFF
--- a/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
+++ b/tools/modules/EnsEMBL/Web/Component/Tools/VEP/InputForm.pm
@@ -57,7 +57,7 @@ sub content {
   $cons{$_}->{colour} = $hub->colourmap->hex_by_name($sd->colour('variation')->{lc $_}->{'default'}) for keys %cons;
 
   # add example data
-  my $ex_data;
+  my $ex_data = {};
 
   foreach my $sp(@$species) {
     foreach my $key(grep {/^VEP/} keys %{$sp->{sample}}) {


### PR DESCRIPTION
Previously if examples are not present there was a runtime error: hash- or arrayref expected (not a simple scalar, use allow_nonref to allow this) at /nfs/public/rw/ensembl/libs/perl/share/perl5/JSON.pm line 154